### PR TITLE
[FIX] WordPress 2021 theme is no longer present in WP by default

### DIFF
--- a/3-4_lab-wordpress/docker-compose.yml
+++ b/3-4_lab-wordpress/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         apk --no-cache add wget unzip &&
         cd /wordpress_data/wp-content/themes &&
         wget -qO- https://downloads.wordpress.org/theme/twentytwentyone.2.2.zip | unzip -q - &&
-        chown -R 33:33 /wordpress_data/wp-content/themes
+        chown -R www-data:www-data /wordpress_data/wp-content/themes
       "
 
 volumes:

--- a/3-4_lab-wordpress/docker-compose.yml
+++ b/3-4_lab-wordpress/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   wordpress:
     depends_on:
       - db
+      - theme-downloader
     image: pwst_wordpress
     build:
         context: .
@@ -29,6 +30,19 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+
+  theme-downloader:
+    image: alpine
+    volumes:
+      - wordpress_data:/wordpress_data
+    command: >
+      sh -c "
+        apk --no-cache add wget unzip &&
+        cd /wordpress_data/wp-content/themes &&
+        wget -qO- https://downloads.wordpress.org/theme/twentytwentyone.2.2.zip | unzip -q - &&
+        chown -R 33:33 /wordpress_data/wp-content/themes
+      "
+
 volumes:
   db_data: {}
   wordpress_data: {}

--- a/3-4_lab-wordpress/docker-compose.yml
+++ b/3-4_lab-wordpress/docker-compose.yml
@@ -15,7 +15,6 @@ services:
   wordpress:
     depends_on:
       - db
-      - theme-downloader
     image: pwst_wordpress
     build:
         context: .
@@ -35,7 +34,7 @@ services:
     image: alpine
     volumes:
       - wordpress_data:/wordpress_data
-    command: >
+    entrypoint: >
       sh -c "
         apk --no-cache add wget unzip &&
         cd /wordpress_data/wp-content/themes &&


### PR DESCRIPTION
When doing the PWAST training at one point I was supposed to insert a reverse shell in the PHP code of the `twentytwentyone` theme in WordPress. I can't find which module, unfortunately, but I think it's in section 3.

However that theme is no longer included in WP by default. The earliest theme available is `twentytwentytwo`. 

I had to manually download the 2021 theme and insert it into the themes folder of the container. I figured that could be automated in the `docker-compose.yml` file so other people wouldn't run into this blocker. 

I didn't need to restart the WP container; it automatically detected the new theme.

This PR spins up an Alpine container to download the 2021 theme into the themes folder of the WP container and then terminates the Alpine container via the `ENTRYPOINT` directive once completed.